### PR TITLE
Added CANCEL_PASS to cancel without creating trace

### DIFF
--- a/ElevatorClient/Commands.cs
+++ b/ElevatorClient/Commands.cs
@@ -33,5 +33,6 @@ namespace Elevator
         public const string START_BROWSER = "START_BROWSER";
         public const string END_BROWSER = "END_BROWSER";
         public const string END_PASS = "END_PASS";
+        public const string CANCEL_PASS = "CANCEL_PASS";
     }
 }

--- a/ElevatorServer/ElevatorServer.cs
+++ b/ElevatorServer/ElevatorServer.cs
@@ -84,6 +84,7 @@ namespace Elevator
                 case Commands.START_BROWSER:
                 case Commands.END_BROWSER:
                 case Commands.END_PASS:
+                case Commands.CANCEL_PASS:
                     break;
                 default:
                     throw new Exception($"Unknown command encountered: {command}");

--- a/ElevatorServer/Program.cs
+++ b/ElevatorServer/Program.cs
@@ -181,6 +181,10 @@ namespace Elevator
                             isPassEnded = true;
 
                             break;
+                        case Commands.CANCEL_PASS:
+                            Console.WriteLine("{0}: Cancelling tracing.", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+                            wpr.CancelWPR();
+                            break;
                         default:
                             throw new Exception($"Unknown command encountered: {command}");
                     } // switch (Command)


### PR DESCRIPTION
CANCEL_PASS can now be provided as a command from the client. This was needed to work with functionality added to TestingPower which tries again when it encounters an exception from the browser
